### PR TITLE
add IntlMessageFormat as a bundler option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 
 node_js:
+  - "5"
+  - "4"
   - "0.12"
-  - "0.10"
-  - "iojs"
 
 sudo: false

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Extract/cache/render property files/strings using i18n rules and various renderi
 ### Initialize bundalo
 
 Call bundalo module with a key that matches your template engine, plus locale information.
-Currently only dust and none are supported as engines.
 
 ```javascript
 var bundalo = require('bundalo');
@@ -20,7 +19,7 @@ var bundalo = require('bundalo');
 var config = {
 	"contentPath": "locales/", //required
 	"fallback": "en-US",       //optional
-	"engine": "dust",          //required
+	"engine": "dust",          //optional, defaults to "none" if not supplied
 	"cache": false             //optional, default is true
 };
 var config2 = {
@@ -74,6 +73,23 @@ bundle.get('bundle': {
 	});
 });
 ```
+
+## Available bundlers
+
+### dust
+
+Uses the dust template engine to handle model substitution
+
+### messageformat
+
+Uses [https://github.com/yahoo/intl-messageformat](https://github.com/yahoo/intl-messageformat) to handle i18n of the strings. If a data 
+model is supplied, the [IntlMessageFormat](https://github.com/yahoo/intl-messageformat#intlmessageformat-constructor) objects 
+will get [resolved](https://github.com/yahoo/intl-messageformat#formatvalues-method) to final content strings. 
+Otherwise, the returned object will hold the base IntlMessageFormat objects for the user to resolve within their own application.
+
+### none
+
+Does no attempted pre-processing of the strings in the properties file
 
 ## Design
 

--- a/bundler/messageformat.js
+++ b/bundler/messageformat.js
@@ -1,0 +1,89 @@
+/*───────────────────────────────────────────────────────────────────────────*\
+ │  Copyright (C) 2014 eBay Software Foundation                                │
+ │                                                                             │
+ │hh ,'""`.                                                                    │
+ │  / _  _ \  Licensed under the Apache License, Version 2.0 (the "License");  │
+ │  |(@)(@)|  you may not use this file except in compliance with the License. │
+ │  )  __  (  You may obtain a copy of the License at                          │
+ │ /,'))((`.\                                                                  │
+ │(( ((  )) ))    http://www.apache.org/licenses/LICENSE-2.0                   │
+ │ `\ `)(' /'                                                                  │
+ │                                                                             │
+ │   Unless required by applicable law or agreed to in writing, software       │
+ │   distributed under the License is distributed on an "AS IS" BASIS,         │
+ │   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  │
+ │   See the License for the specific language governing permissions and       │
+ │   limitations under the License.                                            │
+ \*───────────────────────────────────────────────────────────────────────────*/
+
+/*eslint no-underscore-dangle:0*/
+'use strict';
+var fs = require('fs');
+var spud = require('spud');
+var loopalo = require('../lib/loopalo');
+var Resolver = require('../lib/resolver');
+var IntlMessageFormat = require('intl-messageformat');
+var thing = require('core-util-is');
+var iferr = require('iferr');
+var async = require('async');
+
+
+function IntlFmt(config) {
+    this.resolver = new Resolver(config);
+    this.doCache = (config.cache !== undefined && config.cache === false) ? false : true;
+    this.fallback = config.fallback || 'en-US';
+    this.cache = {};
+}
+
+function formatify(obj, locality, model) {
+    if (thing.isString(obj)) {
+        var fmtObj = new IntlMessageFormat(obj, locality);
+        return (model) ? fmtObj.format(model) : fmtObj;
+    }
+    else if (thing.isObject(obj)) {
+        Object.keys(obj).forEach(function (elt) {
+            obj[elt] = formatify(obj[elt], locality, model);
+        });
+        return obj;
+    }
+    else if (thing.isArray(obj)) {
+        return obj.map(function (elt) {
+            return formatify(elt, locality, model);
+        });
+    }
+    //unconsidered use case? throw an error
+    throw new Error('undefined formatify use case!');
+}
+
+IntlFmt.prototype.get = function (config, callback) {
+    var that = this;
+
+    function intlFmtBundler(bundleFile, cacheKey, cb) {
+        if (that.cache && that.cache[cacheKey]) {
+            async.ensureAsync(cb(null, that.cache[cacheKey]));
+            return;
+        }
+        //not yet in cache
+        fs.readFile(bundleFile, iferr(callback, function handleBundleBuffer(bundleBuffer) {
+            try {
+                var parsed = spud.parse(bundleBuffer.toString());
+                //recurse into the JSON object and convert any string to a IntlMessageFormat object
+                parsed = formatify(parsed, config.locality || that.fallback, config.model || null);
+                if (that.doCache) {
+                    that.cache[cacheKey] = parsed;
+                }
+                cb(null, parsed);
+            } catch (e) {
+                cb(e);
+            }
+        }));
+    }
+
+    loopalo(config.bundle, config, this.resolver, intlFmtBundler, callback);
+};
+
+IntlFmt.prototype.__cache = function () {
+    return this.cache;
+};
+
+module.exports = IntlFmt;

--- a/package.json
+++ b/package.json
@@ -37,11 +37,13 @@
   },
   "dependencies": {
     "async": "^1.3.0",
-    "dustjs-linkedin": "~2.7.2",
+    "core-util-is": "^1.0.2",
     "debuglog": "^1.0.1",
+    "dustjs-linkedin": "~2.7.2",
     "file-resolver": "^1.0.0",
     "freshy": "^1.0.0",
     "iferr": "^0.1.5",
+    "intl-messageformat": "^1.2.0",
     "lodash": "^3.10.0",
     "spud": "^2.0.1",
     "verror": "^1.6.0"

--- a/test/fixture/locales/US/en/complex.properties
+++ b/test/fixture/locales/US/en/complex.properties
@@ -1,0 +1,5 @@
+value=A Value with {numPhotos, plural, =0 {no photos.} =1 {one photo.} other {# photos.}}
+array[0]=First Entry
+array[1]=Second Entry
+map[US]=United States
+map[GB]=United Kingdom

--- a/test/messageformat-test.js
+++ b/test/messageformat-test.js
@@ -1,0 +1,64 @@
+/* global describe, it, before */
+/*eslint no-underscore-dangle: 0*/
+'use strict';
+var bundalo = require("../index");
+var engine = "messageformat";
+var path = require('path');
+var assert = require('assert');
+var thing = require('core-util-is');
+
+describe("bundalo messageformat bundler @messageformat@", function () {
+	it("should return IntlMessageFormat instance resolved to a string with a locale", function (done) {
+		var contentPath = path.join(__dirname, 'fixture', 'locales');
+		var bundle = bundalo({"contentPath": contentPath, "fallback": "en-US", "engine": engine});
+		bundle.get({
+			bundle: 'complex',
+			locality: 'en-US',
+			model: {
+				numPhotos: 1000
+			}
+		}, function bundaloReturn(err, data) {
+			if (err) {
+				return done(err);
+			}
+
+			assert.equal(data.value, 'A Value with 1,000 photos.');
+			done();
+		});
+	});
+	it("should return IntlMessageFormat instance resolved to a string with a fallback locale", function (done) {
+		var contentPath = path.join(__dirname, 'fixture', 'locales');
+		var fallback = "en-US";
+		var bundle = bundalo({"contentPath": contentPath, "fallback": fallback, "engine": engine});
+		bundle.get({
+			bundle: 'complex',
+			locality: 'fr-FR',
+			model: {
+				numPhotos: 1000
+			}
+		}, function bundaloReturn(err, data) {
+			if (err) {
+				return done(err);
+			}
+
+			assert.equal(data.value, 'A Value with 1,000 photos.');
+			done();
+		});
+	});
+	it("should return IntlMessageFormat instances with no model", function (done) {
+		var contentPath = path.join(__dirname, 'fixture', 'locales');
+		var fallback = "";
+		var bundle = bundalo({"contentPath": contentPath, "fallback": fallback, "engine": engine});
+		bundle.get({
+			bundle: 'complex',
+			locality: 'en-US'
+		}, function bundaloReturn(err, data) {
+			if (err) {
+				return done(err);
+			}
+
+			assert.equal(thing.isObject(data.value), true);
+			done();
+		});
+	});
+});


### PR DESCRIPTION
Dust is a bit heavy-handed to do string replacements in content files. Also it lacks actual i18n support. Taking a swipe at adding a bundler based on [https://github.com/yahoo/intl-messageformat](https://github.com/yahoo/intl-messageformat).