### PR TITLE
Upgrade insecure dependencies on 0.x branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/krakenjs/bundalo",
   "devDependencies": {
-    "eslint": "^0.24.1",
+    "eslint": "^2.9.0",
     "mocha": "^2.2.5"
   },
   "dependencies": {
@@ -42,7 +42,7 @@
     "file-resolver": "^1.0.0",
     "freshy": "^1.0.0",
     "iferr": "^0.1.5",
-    "lodash": "^3.10.0",
+    "lodash": "^4.11.2",
     "spud": "^2.0.1",
     "verror": "^1.6.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bundalo",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "Extract/cache/render property files/strings using i18n rules and various rendering engines",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
[lodash 3.x is vulnerable to a prototype pollution vulnerability](https://snyk.io/vuln/SNYK-JS-LODASH-450202). The 1.x branch of bundalo removes lodash, but it also removes support for Dust.js, and Dust is still used by some of our older applications. 

This PR upgrades lodash so we can get the security fix on the 0.x branch.

Tested by running UTs.